### PR TITLE
Update BuildFile.hs

### DIFF
--- a/src/lib/Cook/BuildFile.hs
+++ b/src/lib/Cook/BuildFile.hs
@@ -195,7 +195,7 @@ copyTarAndUnpack um tarName imageDest =
             SkipExisting -> "--skip-old-files"
             OverwriteExisting -> "--overwrite"
          )
-      ++ " -f /" ++ tarName ++ " -C " ++ imageDest
+      ++ tarName ++ " -C " ++ imageDest
       ++ " && rm -rf /" ++ tarName
     ]
 


### PR DESCRIPTION
docker "-f" is deprecated since 1.10 and removed since 1.12 (now).