### PR TITLE
Set the handles to `LineBuffering` on startup

### DIFF
--- a/src/prog/Main.hs
+++ b/src/prog/Main.hs
@@ -82,7 +82,10 @@ runProg' cmd =
 
 main :: IO ()
 main =
-    execParser opts >>= runProg
+    do -- We set the buffering mode here so that we get output immediately
+       hSetBuffering stdout LineBuffering
+       hSetBuffering stderr LineBuffering
+       execParser opts >>= runProg
     where
       opts = info (helper <*> argParse)
              ( fullDesc


### PR DESCRIPTION
This is necessary if you want to attach dockercook to a pipe