### PR TITLE
Special hash for prepare

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,17 @@ This shell command is executed in an empty directory and is useful to copy
 additional files into the build context. Any file that you copy in the
 working directory of the shell-command will be available in your cook file
 from the `/_cookpreps` directory. All `PREPARE` commands in one file will be
-executed in the same preparation directory. For more information check the
-example.
+executed in the same preparation directory.
+
+After running all `PREPARE` commands, dockercook hashes all files
+produced as a dependency checksum.  But sometimes, the content of a file
+is non-deterministic although it's semantics is the same. In these
+situations, taking the hash of the file unnecessarily produces different
+images.  As a solution, you can generate a file called `.cookHash_FILE`
+along with `FILE`.  If the `PREPARE` command finds such a file in the same
+directory as `FILE`, it hashes the `.cookHash_FILE` instead of `FILE`.
+
+For more information on `PREPARE` check the example.
 
 ## COOKCOPY [cookfile] [image-dir] [target-dir]
 
@@ -228,4 +237,3 @@ Lot's of time is saved because you don't need to reinstall all your packages dep
 # Related work
 
 * [docker-buildcache](https://github.com/baremetal/docker-buildcache)
-

--- a/dockercook.cabal
+++ b/dockercook.cabal
@@ -1,5 +1,5 @@
 name:                dockercook
-version:             0.5.0.3
+version:             0.5.1.0
 synopsis:            A build tool for multiple docker image layers
 description:         Build and manage multiple docker image layers to speed up deployment
 license:             MIT

--- a/src/lib/Cook/Build.hs
+++ b/src/lib/Cook/Build.hs
@@ -98,10 +98,8 @@ makeDirectoryFileHashTable hMgr ignore (FP.decodeString . fixTailingSlash -> roo
             Just relToRootF ->
                 let shouldIgnore = ignore relToRootF
                 in if shouldIgnore
-                   then do logDebug ("Ignoring " ++ show relToRootF)
-                           return False
-                   else do logDebug ("Traversing " ++ show relToRootF)
-                           return True
+                   then return False
+                   else return True
       hashFile fullRoot relToCurrentF =
           case FP.stripPrefix root relToCurrentF of
             Nothing ->
@@ -111,11 +109,9 @@ makeDirectoryFileHashTable hMgr ignore (FP.decodeString . fixTailingSlash -> roo
                 hashFile' fullRoot relToRootF (FP.encodeString relToCurrentF)
       hashFile' fullRoot relToRootF relToCurrentF
           | ignore relToRootF =
-              do logDebug ("Ignored " ++ show relToRootF)
-                 return Nothing
+              return Nothing
           | otherwise =
-              do logDebug ("Hashed " ++ show relToRootF)
-                 let fullFilePath = fullRoot </> FP.encodeString relToRootF
+              do let fullFilePath = fullRoot </> FP.encodeString relToRootF
                      hashComp =
                          do bs <- C.sourceFile relToCurrentF $$ C.sinkList
                             liftIO $ hPutStr stderr "#"


### PR DESCRIPTION
When the PREPARE command generates a file, it usually hashes the file
to compute the overall hash of the dependencies. But sometimes, the
content of a file is non-deterministic although it's semantics is the
same. In these situations, taking the hash of the file unnecessarily
produces different images.

As a solution, you can now generate a file call .cookHash_FILE,
where FILE is the file generated by PREPARE. If the PREPARE command
finds such a file in the same directory as FILE, it hashes the
.cookHash_FILE instead of FILE.